### PR TITLE
replacing custom ressource with official iam:samlprovider

### DIFF
--- a/OktaToAppStream.yaml
+++ b/OktaToAppStream.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::IAM::SAMLProvider
     Properties: 
       Name: !Sub OKT-${AppStreamStackName}
-      SamlMetadataDocument: !Ref SamlMetaDataUri
+      SamlMetadataDocument: !Ref SamlMetaDataDocument
   AppStreamRole:
     Type: AWS::IAM::Role
     Properties:

--- a/OktaToAppStream.yaml
+++ b/OktaToAppStream.yaml
@@ -6,16 +6,15 @@ Parameters:
   AppStreamAppName:
     Type: String
     Description: Name of the application
-  SamlMetaDataUri:
+  SamlMetaDataDocument:
     Type: String
-    Description: URI containing the IDP SAML metadata
+    Description: Document containing the IDP SAML metadata
 Resources:
   SamlProvider:
-    Type: Custom::SAMLProvider
-    Properties:
-      ServiceToken: !ImportValue SamlProviderArn
-      MetaDataUri: !Ref SamlMetaDataUri
-      IdentityProviderName: !Sub OKT-${AppStreamStackName}
+    Type: AWS::IAM::SAMLProvider
+    Properties: 
+      Name: !Sub OKT-${AppStreamStackName}
+      SamlMetadataDocument: !Ref SamlMetaDataUri
   AppStreamRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
To achieve https://jira.tx.group/browse/IT-835 we need to get rid of the okta lambda https://github.com/GitHubTamediaEis/AWS-CF-OktaAuthentication/blob/master/OktaAuthentication.yaml